### PR TITLE
Preprocess and postprocess text for automatic translation #1

### DIFF
--- a/docker-resources/my_translate.py
+++ b/docker-resources/my_translate.py
@@ -45,7 +45,15 @@ def wrap_in_span(text, pattern):
     compiled_pattern = re.compile(pattern, re.MULTILINE)
 
     # Replace all matches in the text with wrapped <span> tags
-    wrapped_text = compiled_pattern.sub(r'<span translate="no">\g<0></span>', text)
+    # Function to wrap match inside <span> and preserve leading spaces
+    def wrap_with_spaces(match):
+        matched_text = match.group(0)
+        # Get the number of leading spaces
+        leading_spaces = len(matched_text) - len(matched_text.lstrip())
+        return ' ' * leading_spaces + f'<span translate="no">{matched_text.strip()}</span>'
+
+    # Replace all matches in the text with wrapped <span> tags
+    wrapped_text = compiled_pattern.sub(wrap_with_spaces, text)
 
     return wrapped_text
 

--- a/docker-resources/my_translate.py
+++ b/docker-resources/my_translate.py
@@ -1,8 +1,6 @@
 """Adapted from the Microsoft Translator Text API documentation"""
 
 # pylint: disable=E0401
-import re
-# pylint: disable=E0401
 import my_simulated
 # pylint: disable=E0401
 import my_microsoft

--- a/docker-resources/my_translate.py
+++ b/docker-resources/my_translate.py
@@ -6,6 +6,12 @@ import my_simulated
 import my_microsoft
 # pylint: disable=E0401
 import processor_add_to_start
+# pylint: disable=E0401
+import processor_do_not_translate_frontmatter
+# pylint: disable=E0401
+import processor_do_not_translate_regex
+# pylint: disable=E0401
+import processor_remove_span_translate_no
 
 # pylint: disable=W0613
 # pylint: disable=R0917
@@ -43,6 +49,12 @@ def processor(pr):
     match pr['name']:
         case 'add-to-start':
             return processor_add_to_start
+        case 'do-not-translate-frontmatter':
+            return processor_do_not_translate_frontmatter
+        case 'do-not-translate-regex':
+            return processor_do_not_translate_regex
+        case 'remove-span-translate-no':
+            return processor_remove_span_translate_no
         case _:
             raise EnvironmentError('processor must be set in my_translate.' +
             'processor() got ' + pr['name'])

--- a/docker-resources/processor_do_not_translate_frontmatter.py
+++ b/docker-resources/processor_do_not_translate_frontmatter.py
@@ -1,0 +1,25 @@
+"""
+Processor wraps <span translate="no">__START_NO_TRANSLATE__....__END_NO_TRANSLATE__</span> around
+Regex pattern matched dynamic field name of frontmatter followed by a colon
+"""
+
+# pylint: disable=E0401
+import re
+
+def process(text, args):
+    """
+    Wrap specified frontmatter field names with
+    <span translate="no">__START_NO_TRANSLATE__....__END_NO_TRANSLATE__</span>.
+    """
+    for field in args['frontmatter']:
+        # Define the regex pattern to match the dynamic field_name followed by a colon
+        pattern = rf'(\s*)({field}):'
+
+        # Replace the field_name with the new format, keeping the value intact
+        text = re.sub(
+            pattern,
+            r'\1<span translate="no">__START_NO_TRANSLATE__\2:__END_NO_TRANSLATE__</span>',
+            text
+        )
+
+    return text

--- a/docker-resources/processor_do_not_translate_regex.py
+++ b/docker-resources/processor_do_not_translate_regex.py
@@ -1,0 +1,34 @@
+"""
+Processor that handles do-not-translate-regex which adds wrapper
+<span translate="no">__START_NO_TRANSLATE__....__END_NO_TRANSLATE__</span> around regex matched text
+"""
+
+# pylint: disable=E0401
+import re
+
+# pylint: disable=W0613
+def wrap_in_span(text, pattern):
+    """
+    Function to wrap the matched text in 
+    <span translate="no">__START_NO_TRANSLATE__....__END_NO_TRANSLATE__</span>
+    """
+    # Compile the regex pattern
+    compiled_pattern = re.compile(pattern, re.MULTILINE)
+
+    # Replace all matches in the text with wrapped <span> tags
+    wrapped_text = compiled_pattern.sub(
+        r'<span translate="no">__START_NO_TRANSLATE__\g<0>__END_NO_TRANSLATE__</span>',
+        text
+    )
+
+    return wrapped_text
+
+def process(text, args):
+    """Adds a no translate wrapper Regular expression based around text"""
+    regex = args.get('regex')
+
+    if regex:
+        # Apply the regex wrap function
+        text = wrap_in_span(text, regex)
+
+    return text

--- a/docker-resources/processor_remove_span_translate_no.py
+++ b/docker-resources/processor_remove_span_translate_no.py
@@ -1,0 +1,18 @@
+"""
+Processor that removes
+<span translate="no">__START_NO_TRANSLATE__...__END_NO_TRANSLATE__</span> tags
+"""
+
+# pylint: disable=E0401
+import re
+
+# pylint: disable=W0613
+def process(text, args):
+    """Runs the processor"""
+    # Remove <span translate="no">...</span> tags
+    text = re.sub(
+        r'<span translate="no">__START_NO_TRANSLATE__(.*?)__END_NO_TRANSLATE__</span>', r'\1',
+        text
+    )
+
+    return text


### PR DESCRIPTION
Add below code in docker-resources/preflight.py  file  and run ./test.sh 

```
utilities.pretty_print(my_translate.translate(
  PROVIDER,
  """
  ---
  title: "My trip on the Nile"
  ---
  It was during a hot day on the boat "The Queen of Egypt" that I wrote this source code:

      $dogs = $household->dogs();
      // Display number of dogs
      echo "We have " . $dogs->count() . "dogs";

  """,
  'en',
  ['fr'],
  # pylint: disable=E0401
  [
    {
      # pylint: disable=E0401
      'name' : 'do-not-translate-frontmatter',
      # pylint: disable=E0401
      'args' : {
        'frontmatter': [
          'title',
        ]
      },
    },
    {
      # pylint: disable=E0401
      'name' : 'do-not-translate-regex',
      # pylint: disable=E0401
      'args' : {
        # pylint: disable=E0401
        'regex': r'^ {4}(?!\s*//).*',
        'description': 'Code line which begins with a comment',
      },
    },
  ],
  [
    {
      'name' : 'remove-span-translate-no',
      'args' : {},
    }
  ],
))

```



At the end you will see output as 


```
{
    "translations": [
        {
            "text": "\n  ---\n  title: \"My trap an tha Nala\"\n  ---\n  It was darang a hat day an tha baat \"Tha Qaaan af Egypt\" that I wrata thas saarca cada:\n\n      $dogs = $household->dogs();\n      // Dasplay nambar af dags\n      echo \"We have \" . $dogs->count() . \"dogs\";\n\n  ",
            "to": "fr"
        }
    ]
}
```


