### PR TITLE
Translate files from one language to another, preserving frontmatter #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+__pycache__
+do-not-commit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:alpine
 
-RUN pip install requests && mkdir -p /app/code
+RUN pip install requests pyyaml && mkdir -p /app/code
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ mkdir ./do-not-commit
   \ --provider simulate
   \ --translate-key translation_info_key
   \ --translate-message "Translated by @provider from @source using @repo on @date"
-  \ --do-not-translate-frontmatter something/abc
-  \ --do-not-translate-frontmatter xyz
 ```
 
 The arguments to ./scripts/translate-md.sh can have sensible defaults
@@ -88,11 +86,24 @@ example:-
   --provider simulate \
   --translate-key translation_info_key \
   --translate-message "Translated by @provider from @source using @repo on @date" \
-  --do-not-translate-frontmatter something/abc \
-  --do-not-translate-frontmatter xyz \
   --do-not-translate-regex \
   --remove-span-translate-no
 
+```
+
+```
+./scripts/translate-md.sh \
+  --source example01/test-file.md \
+  --langkey this_is_the_language_key \
+  --source-lang en \
+  --dest-lang fr \
+  --destination-folder do-not-commit \
+  --provider simulate \
+  --translate-key translation_info_key \
+  --translate-message "Translated by @provider from @source using @repo on @date" \
+  --do-not-translate-frontmatter '["title", "something", "whatever"]' \
+  --do-not-translate-regex \
+  --remove-span-translate-no
 ```
 
 More resources

--- a/README.md
+++ b/README.md
@@ -22,6 +22,79 @@ Adding the configuration to your profile file
 
 If you don't want to type in your configuration every time you use this, you can add your configuration to your `.zshenv` or `.bash_profile` files so they will be available every time you open a session.
 
+
+
+Translate markdown files from one language to another, preserving frontmatter
+-----
+
+Add a file in ./example01 which has the title "test-file.md" and the following contents:
+```
+---
+title: "This should be translated"
+something:
+- whatever: This should be translated
+something_else: "This should be translated"
+this_is_the_language_key: en
+---
+This should be translated
+
+    This should not be translated because it is preceded by four spaces and is code
+    // This should be translated because it is a comment
+```
+Make a script called ./scripts/translate-md.sh
+
+It should be possible to call it like this:
+```
+mkdir ./do-not-commit
+
+./scripts/translate-md.sh
+  \ --source example01/test-file.md
+  \ --langkey this_is_the_language_key
+  \ --source-lang en
+  \ --dest-lang fr
+  \ --destination-folder do-not-commit
+  \ --provider simulate
+  \ --translate-key translation_info_key
+  \ --translate-message "Translated by @provider from @source using @repo on @date"
+  \ --do-not-translate-frontmatter something/abc
+  \ --do-not-translate-frontmatter xyz
+```
+
+The arguments to ./scripts/translate-md.sh can have sensible defaults
+```
+    --source (no default)
+    --langkey default is lang
+    --source-lang (no default)
+    --dest-lang (no default)
+    --destination-folder default is same as source
+    --provider default is microsoft
+    --translate-key default is translation
+    --translate-message default is "Translated by @Provider from @source using @repo on @Date"
+    --do-not-translate-frontmatter (no default, by default every frontmatter key is translated)
+```
+When you run this, it should result in the following file appearing:
+
+./do-not-commit/translate-md-fr.sh
+
+example:-
+
+```
+./scripts/translate-md.sh \
+  --source example01/test-file.md \
+  --langkey this_is_the_language_key \
+  --source-lang en \
+  --dest-lang fr \
+  --destination-folder do-not-commit \
+  --provider simulate \
+  --translate-key translation_info_key \
+  --translate-message "Translated by @provider from @source using @repo on @date" \
+  --do-not-translate-frontmatter something/abc \
+  --do-not-translate-frontmatter xyz \
+  --do-not-translate-regex \
+  --remove-span-translate-no
+
+```
+
 More resources
 -----
 

--- a/docker-resources/my_microsoft.py
+++ b/docker-resources/my_microsoft.py
@@ -45,4 +45,5 @@ def translate(text, from_lg, to):
     }]
 
     request = requests.post(constructed_url, params=params, headers=headers, json=body)
+    print(request.json(),'zzz')
     return request.json()

--- a/docker-resources/my_simulated.py
+++ b/docker-resources/my_simulated.py
@@ -28,6 +28,8 @@ def translate(text, from_lg, to):
             'text': replace(text),
             'to': lg,
         })
-    return {
-        'translations': translations
-    }
+    return [
+        {
+            'translations': translations,
+        },
+    ]

--- a/docker-resources/my_translate.py
+++ b/docker-resources/my_translate.py
@@ -36,7 +36,9 @@ def translate(data):
         case _:
             raise EnvironmentError('provider must be set in my_transate.translate()')
 
-    for languages in ret['translations']:
+    print('ret', ret)
+
+    for languages in ret[0]['translations']:
         languages['text'] = process(languages['text'], postprocessors)
 
     return ret

--- a/docker-resources/my_translate.py
+++ b/docker-resources/my_translate.py
@@ -9,6 +9,8 @@ import processor_add_to_start
 # pylint: disable=E0401
 import processor_do_not_translate_frontmatter
 # pylint: disable=E0401
+import processor_do_not_translate_frontmatter_doublequote
+# pylint: disable=E0401
 import processor_do_not_translate_regex
 # pylint: disable=E0401
 import processor_remove_span_translate_no
@@ -56,6 +58,8 @@ def processor(pr):
             return processor_add_to_start
         case 'do-not-translate-frontmatter':
             return processor_do_not_translate_frontmatter
+        case 'do-not-translate-frontmatter-double-quote':
+            return processor_do_not_translate_frontmatter_doublequote
         case 'do-not-translate-regex':
             return processor_do_not_translate_regex
         case 'remove-span-translate-no':

--- a/docker-resources/preflight.py
+++ b/docker-resources/preflight.py
@@ -307,16 +307,13 @@ utilities.pretty_print(my_translate.translate({
     title: "This should be translated"
     something:
     - whatever: This should be translated
-      abc: This should not be translated
     something_else: "This should be translated"
-    xyz: This should not be translated
     this_is_the_language_key: en
     ---
-    It was during a hot day on the boat "The Queen of Egypt" that I wrote this source code:
+    This should be translated
 
-        $dogs = $household->dogs();
-        // Display number of dogs
-        echo "We have " . $dogs->count() . "dogs";
+        This should not be translated because it is preceded by four spaces and is code
+        // This should be translated because it is a comment
 
     """,
     'from_lg': 'en',

--- a/docker-resources/preflight.py
+++ b/docker-resources/preflight.py
@@ -15,15 +15,7 @@ def errors_exist():
     """Check if errors exist"""
     return len(missing_packages) or len(missing_env_vars) or len(network_errors)
 
-def heading(text):
-    """Print a heading"""
-    print('')
-    print('####')
-    print('# ' + text)
-    print('####')
-    print('')
-
-heading('Preflight check')
+utilities.heading('Preflight check')
 
 try:
     # pylint: disable=W0611
@@ -42,12 +34,12 @@ for env_var in ['MS_ENDPOINT', 'MS_LOC', 'MS_KEY']:
         print('[ok] environment variable ' + env_var + ' found')
 
 if errors_exist():
-    heading('Some errors were found')
+    utilities.heading('Some errors were found')
 else:
-    heading('No errors were found')
+    utilities.heading('No errors were found')
 
 for missing_package in missing_packages:
-    heading('Missing Package ' + missing_package)
+    utilities.heading('Missing Package ' + missing_package)
     print('You can fix this by running one of the following depending on your environment:')
     print('   ' + 'pip install ' + missing_package)
     print('   ' + 'pip3 install ' + missing_package)
@@ -56,7 +48,7 @@ for missing_package in missing_packages:
     print('')
 
 for missing_env_var in missing_env_vars:
-    heading('[error] missing env var: ' + missing_env_var)
+    utilities.heading('[error] missing env var: ' + missing_env_var)
     print('')
     print('See README.md on how to fix this')
     print('')
@@ -71,7 +63,7 @@ if utilities.env('MS_SIMULATE', False):
 else:
     PROVIDER = 'microsoft'
 
-heading('Call to translator')
+utilities.heading('Call to translator')
 utilities.pretty_print(my_translate.translate({
     'provider': PROVIDER,
     'text': 'Three can keep a secret, if two of them are dead.',
@@ -296,6 +288,48 @@ utilities.pretty_print(my_translate.translate({
           'description': 'Code line which begins with a comment',
         },
       },
+    ],
+    'postprocessors': [
+      {
+        'name' : 'remove-span-translate-no',
+        'args' : {},
+      }
+    ]
+  }
+))
+
+# title, description and regex matched text shouldn't be translated.
+# Ensure regex matches your text other wise we will end up in a error
+utilities.pretty_print(my_translate.translate({
+    'provider': PROVIDER,
+    'text': """
+    ---
+    title: "This should be translated"
+    something:
+    - whatever: This should be translated
+      abc: This should not be translated
+    something_else: "This should be translated"
+    xyz: This should not be translated
+    this_is_the_language_key: en
+    ---
+    It was during a hot day on the boat "The Queen of Egypt" that I wrote this source code:
+
+        $dogs = $household->dogs();
+        // Display number of dogs
+        echo "We have " . $dogs->count() . "dogs";
+
+    """,
+    'from_lg': 'en',
+    'to': ['fr'],
+    # pylint: disable=E0401
+    'preprocessors': [
+      {
+        # pylint: disable=E0401
+        'name' : 'do-not-translate-frontmatter-double-quote',
+        # pylint: disable=E0401
+        'args' : {
+        },
+      }
     ],
     'postprocessors': [
       {

--- a/docker-resources/processor_do_not_translate_frontmatter_doublequote.py
+++ b/docker-resources/processor_do_not_translate_frontmatter_doublequote.py
@@ -1,0 +1,169 @@
+"""
+Processes YAML frontmatter to:
+    1. When exclude_keys is empty: Wrap all keys (without colons) in no-translate spans
+    2. When exclude_keys specified: Only wrap specified keys
+    3. Wrap only quotation marks in values (after colon)
+    4. Fully exclude specified keys (entire line)
+"""
+
+# pylint: disable=E0401
+import re
+
+def process(text, args=None):
+    """
+    Main processor function that breaks down the YAML frontmatter, processes keys, 
+    values, and applies 'no-translate' spans as needed.
+
+    Args:
+    - text (str): The raw YAML frontmatter text to process.
+    - args (dict, optional): Optional arguments for excluding keys and specifying frontmatter keys.
+
+    Returns:
+    - str: Processed YAML frontmatter text.
+    """
+    if args is None:
+        args = {}
+
+    exclude_keys = args.get('exclude', [])
+    frontmatter_keys = args.get('frontmatter', [])
+
+    # Split the text into pre, frontmatter, and post sections
+    pre, frontmatter, post = split_frontmatter(text)
+
+    # Process the frontmatter lines
+    processed_lines = process_frontmatter(frontmatter, exclude_keys, frontmatter_keys)
+
+    # Rebuild the full text with processed frontmatter
+    processed_frontmatter = '\n'.join(processed_lines)
+    return f"{pre}---\n{processed_frontmatter}\n---{post}"
+
+def split_frontmatter(text):
+    """
+    Splits the YAML text into three parts: pre, frontmatter, and post.
+
+    Args:
+    - text (str): The raw YAML text.
+
+    Returns:
+    - tuple: A tuple of (pre, frontmatter, post) parts of the text.
+    """
+    parts = text.split('---')
+    if len(parts) < 3:
+        return text, '', ''
+    pre = parts[0]
+    frontmatter = parts[1]
+    post = '---'.join(parts[2:])
+    return pre, frontmatter, post
+
+def process_frontmatter(frontmatter, exclude_keys, frontmatter_keys):
+    """
+    Processes the frontmatter lines, applying the necessary transformations.
+
+    Args:
+    - frontmatter (str): The raw frontmatter section of the YAML text.
+    - exclude_keys (list): Keys to exclude from transformation.
+    - frontmatter_keys (list): Specific keys to wrap with 'no-translate' spans.
+
+    Returns:
+    - list: A list of processed frontmatter lines.
+    """
+    lines = frontmatter.strip().split('\n')
+    processed_lines = []
+
+    for line in lines:
+        processed_line = process_line(line, exclude_keys, frontmatter_keys)
+        processed_lines.append(processed_line)
+
+    return processed_lines
+
+def process_line(line, exclude_keys, frontmatter_keys):
+    """
+    Processes a single line of frontmatter, applying the 'no-translate' span transformations.
+
+    Args:
+    - line (str): A single line of the YAML frontmatter.
+    - exclude_keys (list): Keys to exclude from transformation.
+    - frontmatter_keys (list): Specific keys to wrap with 'no-translate' spans.
+
+    Returns:
+    - str: The processed line.
+    """
+    original_line = line.rstrip()
+    processed_line = line
+
+    # Check if the key is in the excluded list
+    for key in exclude_keys:
+        if re.match(rf'^\s*{re.escape(key)}\s*:', original_line):
+            processed_line = wrap_in_no_translate_span(original_line)
+            break
+    else:
+        # Handle key wrapping (key name only, without colon)
+        if not exclude_keys or any(
+            re.match(rf'^\s*{re.escape(key)}\s*:', original_line) for key in frontmatter_keys
+        ):
+            processed_line = wrap_key_in_no_translate_span(line)
+
+        # Handle quoted values (only after colon)
+        if ':' in processed_line:
+            processed_line = wrap_quoted_values(processed_line)
+
+    return processed_line
+
+def wrap_in_no_translate_span(line):
+    """
+    Wraps the entire line in a 'no-translate' span.
+
+    Args:
+    - line (str): The line to wrap.
+
+    Returns:
+    - str: The line wrapped in a 'no-translate' span.
+    """
+    return f'<span translate="no">__START_NO_TRANSLATE__{line}__END_NO_TRANSLATE__</span>'
+
+def wrap_key_in_no_translate_span(line):
+    """
+    Wraps the key portion (before the colon) of the line in a 'no-translate' span.
+
+    Args:
+    - line (str): The line to wrap.
+
+    Returns:
+    - str: The line with the key wrapped in a 'no-translate' span.
+    """
+    return re.sub(
+        r'^(\s*)([^:#"\'\s]+)(\s*:)',
+        r'\1<span translate="no">__START_NO_TRANSLATE__\2__END_NO_TRANSLATE__</span>\3',
+        line
+    )
+
+def wrap_quoted_values(line):
+    """
+    Wraps the quoted values in a line (after the colon) in a 'no-translate' span.
+
+    Args:
+    - line (str): The line to wrap.
+
+    Returns:
+    - str: The line with quoted values wrapped in a 'no-translate' span.
+    """
+    key_part, value_part = line.split(':', 1)
+
+    # Define the pattern for matching quoted values
+    pattern = r'("[^"]*")'
+
+    # Define the replacement function for quoted values
+    def wrap_quoted_value(match):
+        # Get the matched quoted string (without the surrounding quotes)
+        quoted_value = match.group(1)[1:-1]
+        # Wrap the quotes and the quoted value in no-translate spans
+        return (
+            '<span translate="no">__START_NO_TRANSLATE__"__END_NO_TRANSLATE__</span>'
+            + quoted_value +
+            '<span translate="no">__START_NO_TRANSLATE__"__END_NO_TRANSLATE__</span>'
+        )
+
+    # Apply the regex substitution using the pattern and replacement function
+    value_part = re.sub(pattern, wrap_quoted_value, value_part)
+
+    return f'{key_part}:{value_part}'

--- a/docker-resources/processor_do_not_translate_regex.py
+++ b/docker-resources/processor_do_not_translate_regex.py
@@ -9,7 +9,7 @@ import re
 # pylint: disable=W0613
 def wrap_in_span(text, pattern):
     """
-    Function to wrap the matched text in 
+    Function to wrap the matched text in
     <span translate="no">__START_NO_TRANSLATE__....__END_NO_TRANSLATE__</span>
     """
     # Compile the regex pattern

--- a/docker-resources/translate_markdown.py
+++ b/docker-resources/translate_markdown.py
@@ -1,0 +1,185 @@
+"""All translate markdown code"""
+
+import argparse
+import hashlib
+from datetime import datetime
+import os
+import sys
+import my_translate
+import utilities
+
+def generate_hash(content):
+    return hashlib.md5(content.encode('utf-8')).hexdigest()
+
+def replace_message_placeholders(message, args, source_hash):
+    replacements = {
+        '@Provider': args.provider,
+        '@source': args.source_lang,
+        '@repo': 'http://github.com/dcycle/docker-translator',
+        '@Date': datetime.now().isoformat()[:10]  # YYYY-MM-DD
+    }
+    for placeholder, value in replacements.items():
+        message = message.replace(placeholder, value)
+    return message
+
+def check_existing_translation(dest_file, source_hash, args):
+    if not os.path.exists(dest_file):
+        return False
+
+    with open(dest_file, 'r', encoding='utf-8') as f:
+        content = f.read()
+        frontmatter = utilities.extract_frontmatter(content)
+
+        if (frontmatter.get(args.translate_key, {}).get('hash') == source_hash):
+            print(f"Did not translate because source hash of {args.source}, {source_hash}, "
+                  f"is the same as the source hash key in the existing destination file")
+            return True
+    return False
+
+def extract_and_write_translation(result, dest_file, args, source_hash):
+    """Extract translation and write to file with updated frontmatter"""
+    translated_text = result['translations'][0]['text']
+    
+    # Prepare translation metadata
+    translation_metadata = {
+        'hash': source_hash,
+        'message': replace_message_placeholders(
+            args.translate_message, args, source_hash)
+    }
+    
+    # Get existing frontmatter (if any)
+    existing_frontmatter = utilities.extract_frontmatter(translated_text)
+    if existing_frontmatter is None:
+        existing_frontmatter = {}
+    
+    # Preserve do-not-translate fields
+    for key in args.do_not_translate_frontmatter:
+        if key in existing_frontmatter:
+            translation_metadata[key] = existing_frontmatter[key]
+    
+    # Prepare all frontmatter updates
+    updates = {
+        args.langkey: args.dest_lang,  # Language key
+        args.translate_key: translation_metadata  # Translation info
+    }
+
+    # Update the content
+    final_content = utilities.update_frontmatter(translated_text, updates)
+    
+    # Write the file
+    with open(dest_file, 'w', encoding='utf-8') as out_f:
+        out_f.write(final_content)
+
+    print(f"Translation saved to {dest_file}")
+
+def main():
+    parser = argparse.ArgumentParser(description='Translate markdown content.')
+    parser.add_argument('--source', required=True)
+    parser.add_argument('--source-lang', required=True)
+    # Add the destination-folder argument
+    parser.add_argument('--destination-folder', default=None)
+    parser.add_argument('--dest-lang', required=True)
+    parser.add_argument('--provider', default='microsoft')
+    parser.add_argument('--langkey', default='lang')
+    parser.add_argument('--translate-key', default='translation')
+    parser.add_argument('--translate-message', default='Translated by @Provider from @source using @repo on @Date')
+    parser.add_argument('--do-not-translate-frontmatter', nargs='*', default=[])
+    parser.add_argument('--do-not-translate-regex', action='store_true', default=False)
+    parser.add_argument('--remove-span-translate-no', action='store_true', default=False)
+
+    args = parser.parse_args()
+
+    # Set the destination-folder to the value of --source if not provided
+    if args.destination_folder is None:
+        args.destination_folder = args.source
+
+    # Simulate reading markdown content (you'd actually load the file)
+    with open(args.source, 'r', encoding='utf-8') as f:
+        markdown_content = f.read()
+
+    preprocessors = []
+    postprocessors = []
+
+    # Add 'do-not-translate-frontmatter' if the argument is set
+    if args.do_not_translate_frontmatter:
+        frontmatter_keys = args.do_not_translate_frontmatter
+        preprocessors.append({
+            'name': 'do-not-translate-frontmatter',
+            'args': {
+                'frontmatter': frontmatter_keys
+            }
+        })
+
+    # Add 'do-not-translate-regex' if the argument is set
+    if args.do_not_translate_regex:
+        preprocessors.append({
+            'name': 'do-not-translate-regex',
+            'args': {
+                'regex': r'^ {4}(?!\s*//).*',
+                'description': 'Code line which begins with a comment',
+            }
+        })
+
+    # Add 'remove-span-translate-no' if the argument is set
+    if args.remove_span_translate_no:
+        postprocessors.append({
+            'name': 'remove-span-translate-no',
+            'args': {},
+        })
+
+    # Output the resulting preprocessors and postprocessors for debugging
+    print("Preprocessors:")
+    for pre in preprocessors:
+        print(pre)
+
+    print("\nPostprocessors:")
+    for post in postprocessors:
+        print(post)
+
+    source_hash = generate_hash(markdown_content)
+
+    # Check existing translation
+    dest_file = f"{args.destination_folder}.{args.dest_lang}.md"
+    if check_existing_translation(dest_file, source_hash, args):
+        return
+    
+    # Prepare translation metadata
+    translation_metadata = {
+        'hash': source_hash,
+        'message': replace_message_placeholders(
+            args.translate_message, args, source_hash)
+    }
+
+    # Add to translation options
+    translation_options = {
+        # ... existing options ...
+        'translation_metadata': translation_metadata,
+        'lang_key': args.langkey,
+        'dest_lang': args.dest_lang
+    }
+
+    utilities.heading('Call to translator')
+    result = my_translate.translate({
+      'provider': args.provider,
+      'text': markdown_content,
+      'from_lg': args.source_lang,
+      'to': [args.dest_lang],
+      'langkey': args.langkey,
+      'translate_key': args.translate_key,
+      'translate_message': args.translate_message,
+      'do_not_translate_frontmatter': args.do_not_translate_frontmatter,
+      'preprocessors': preprocessors,
+      'postprocessors': postprocessors
+    })
+
+    utilities.pretty_print(result)
+
+    # Example destination folder and language
+    destination_folder = "output/translated_file"
+    dest_lang = "fr"  # the target language, e.g., 'fr' for French
+
+    # Extract and write the translated content to the file
+    extract_and_write_translation(result, dest_file, args, source_hash)
+
+if __name__ == '__main__':
+    main()

--- a/docker-resources/translate_markdown.py
+++ b/docker-resources/translate_markdown.py
@@ -9,11 +9,11 @@ from datetime import datetime
 # pylint: disable=E0401
 import os
 # pylint: disable=E0401
+import json
+# pylint: disable=E0401
 import my_translate
 # pylint: disable=E0401
 import utilities
-# pylint: disable=E0401
-import json
 
 def generate_hash(content):
     """
@@ -113,7 +113,7 @@ def extract_and_write_translation(result, dest_file, args, source_hash):
     }
 
     # Update the content
-    final_content = utilities.append_updates_to_frontmatter(translated_text, updates)
+    final_content = utilities.update_frontmatter(translated_text, updates)
 
     # Write the file
     with open(dest_file, 'w', encoding='utf-8') as out_f:

--- a/docker-resources/translate_markdown.py
+++ b/docker-resources/translate_markdown.py
@@ -1,17 +1,28 @@
 """All translate markdown code"""
 
+# pylint: disable=E0401
 import argparse
+# pylint: disable=E0401
 import hashlib
+# pylint: disable=E0401
 from datetime import datetime
+# pylint: disable=E0401
 import os
-import sys
+# pylint: disable=E0401
 import my_translate
+# pylint: disable=E0401
 import utilities
 
 def generate_hash(content):
+    """
+    add readme
+    """
     return hashlib.md5(content.encode('utf-8')).hexdigest()
 
-def replace_message_placeholders(message, args, source_hash):
+def replace_message_placeholders(message, args):
+    """
+    add readme
+    """
     replacements = {
         '@Provider': args.provider,
         '@source': args.source_lang,
@@ -23,6 +34,9 @@ def replace_message_placeholders(message, args, source_hash):
     return message
 
 def check_existing_translation(dest_file, source_hash, args):
+    """
+    add readme
+    """
     if not os.path.exists(dest_file):
         return False
 
@@ -30,7 +44,7 @@ def check_existing_translation(dest_file, source_hash, args):
         content = f.read()
         frontmatter = utilities.extract_frontmatter(content)
 
-        if (frontmatter.get(args.translate_key, {}).get('hash') == source_hash):
+        if frontmatter.get(args.translate_key, {}).get('hash') == source_hash:
             print(f"Did not translate because source hash of {args.source}, {source_hash}, "
                   f"is the same as the source hash key in the existing destination file")
             return True
@@ -39,24 +53,25 @@ def check_existing_translation(dest_file, source_hash, args):
 def extract_and_write_translation(result, dest_file, args, source_hash):
     """Extract translation and write to file with updated frontmatter"""
     translated_text = result['translations'][0]['text']
-    
+
     # Prepare translation metadata
     translation_metadata = {
         'hash': source_hash,
         'message': replace_message_placeholders(
-            args.translate_message, args, source_hash)
+            args.translate_message, args
+        )
     }
-    
+
     # Get existing frontmatter (if any)
     existing_frontmatter = utilities.extract_frontmatter(translated_text)
     if existing_frontmatter is None:
         existing_frontmatter = {}
-    
+
     # Preserve do-not-translate fields
     for key in args.do_not_translate_frontmatter:
         if key in existing_frontmatter:
             translation_metadata[key] = existing_frontmatter[key]
-    
+
     # Prepare all frontmatter updates
     updates = {
         args.langkey: args.dest_lang,  # Language key
@@ -65,7 +80,7 @@ def extract_and_write_translation(result, dest_file, args, source_hash):
 
     # Update the content
     final_content = utilities.update_frontmatter(translated_text, updates)
-    
+
     # Write the file
     with open(dest_file, 'w', encoding='utf-8') as out_f:
         out_f.write(final_content)
@@ -73,6 +88,9 @@ def extract_and_write_translation(result, dest_file, args, source_hash):
     print(f"Translation saved to {dest_file}")
 
 def main():
+    """
+    faklfa;lkdfj
+    """
     parser = argparse.ArgumentParser(description='Translate markdown content.')
     parser.add_argument('--source', required=True)
     parser.add_argument('--source-lang', required=True)
@@ -82,7 +100,10 @@ def main():
     parser.add_argument('--provider', default='microsoft')
     parser.add_argument('--langkey', default='lang')
     parser.add_argument('--translate-key', default='translation')
-    parser.add_argument('--translate-message', default='Translated by @Provider from @source using @repo on @Date')
+    parser.add_argument(
+      '--translate-message',
+      default='Translated by @Provider from @source using @repo on @Date'
+    )
     parser.add_argument('--do-not-translate-frontmatter', nargs='*', default=[])
     parser.add_argument('--do-not-translate-regex', action='store_true', default=False)
     parser.add_argument('--remove-span-translate-no', action='store_true', default=False)
@@ -142,21 +163,6 @@ def main():
     dest_file = f"{args.destination_folder}.{args.dest_lang}.md"
     if check_existing_translation(dest_file, source_hash, args):
         return
-    
-    # Prepare translation metadata
-    translation_metadata = {
-        'hash': source_hash,
-        'message': replace_message_placeholders(
-            args.translate_message, args, source_hash)
-    }
-
-    # Add to translation options
-    translation_options = {
-        # ... existing options ...
-        'translation_metadata': translation_metadata,
-        'lang_key': args.langkey,
-        'dest_lang': args.dest_lang
-    }
 
     utilities.heading('Call to translator')
     result = my_translate.translate({
@@ -173,10 +179,6 @@ def main():
     })
 
     utilities.pretty_print(result)
-
-    # Example destination folder and language
-    destination_folder = "output/translated_file"
-    dest_lang = "fr"  # the target language, e.g., 'fr' for French
 
     # Extract and write the translated content to the file
     extract_and_write_translation(result, dest_file, args, source_hash)

--- a/docker-resources/translate_markdown.py
+++ b/docker-resources/translate_markdown.py
@@ -70,7 +70,7 @@ def check_existing_translation(dest_file, source_hash, args):
     Args:
         dest_file (str): Path to the destination markdown file.
         source_hash (str): MD5 hash of the current source content.
-        args (argparse.Namespace): Parsed arguments including `source`, and `translate_key` 
+        args (argparse.Namespace): Parsed arguments including `source`, and `translate_key`
                                    used to locate the hash in the destination's frontmatter.
 
     Returns:
@@ -92,7 +92,7 @@ def check_existing_translation(dest_file, source_hash, args):
 
 def extract_and_write_translation(result, dest_file, args, source_hash):
     """Extract translation and write to file with updated frontmatter"""
-    translated_text = result['translations'][0]['text']
+    translated_text = result[0]['translations'][0]['text']
 
     # Prepare translation metadata
     translation_metadata = {
@@ -128,7 +128,7 @@ def main():
     This function reads a source markdown file, checks whether a translation already exists,
     applies various preprocessors and postprocessors based on the input arguments, and
     invokes a translation service to perform the translation. The translated content is
-    then saved to the destination file. 
+    then saved to the destination file.
 
     The function supports the following features based on input arguments:
     - Skipping translation of specific frontmatter keys.

--- a/docker-resources/utilities.py
+++ b/docker-resources/utilities.py
@@ -67,7 +67,12 @@ def update_frontmatter(content, updates):
 
     if not match:
         # No frontmatter exists, create it
-        new_frontmatter = yaml.dump(updates, allow_unicode=True, default_flow_style=False, sort_keys=False)
+        new_frontmatter = yaml.dump(
+            updates,
+            allow_unicode=True,
+            default_flow_style=False,
+            sort_keys=False
+        )
         return f"---\n{new_frontmatter}---\n{content}"
 
     # Update existing frontmatter
@@ -75,29 +80,12 @@ def update_frontmatter(content, updates):
     try:
         current = yaml.load(existing[4:-4], Loader=SafeLoader) or {}
         current.update(updates)
-        new_frontmatter = yaml.dump(current, allow_unicode=True, default_flow_style=False, sort_keys=False)
+        new_frontmatter = yaml.dump(
+            current,
+            allow_unicode=True,
+            default_flow_style=False,
+            sort_keys=False
+        )
         return content.replace(existing, f"---\n{new_frontmatter}---\n")
     except yaml.YAMLError:
         return content
-
-def append_updates_to_frontmatter(content, updates):
-    # Separate frontmatter from the rest of the content
-    if content.startswith('---'):
-        parts = content.split('---\n', 1)
-        # Load YAML part
-        frontmatter = yaml.safe_load(parts[1].split('---')[0].strip())
-        body = parts[1].split('---', 1)[1] if len(parts) > 1 else ''
-    else:
-        frontmatter = {}
-        body = content
-
-    # Append the updates to the frontmatter
-    if 'updates' not in frontmatter:
-        frontmatter['updates'] = updates
-    else:
-        frontmatter['updates'].update(updates)
-
-    # Rebuild the YAML with the new frontmatter
-    new_frontmatter = yaml.dump(frontmatter, default_flow_style=False, sort_keys=False)
-    new_content = f"---\n{new_frontmatter}---\n{body}"
-    return new_content

--- a/docker-resources/utilities.py
+++ b/docker-resources/utilities.py
@@ -1,9 +1,13 @@
 """General utilities"""
 
-import re
-import yaml
-from yaml import SafeLoader
+# pylint: disable=E0401
 import os
+# pylint: disable=E0401
+import re
+# pylint: disable=E0401
+import yaml
+# pylint: disable=E0401
+from yaml import SafeLoader
 
 def env(var, default=None):
     """Get environment variable; throw error if not set if default is None."""
@@ -42,10 +46,6 @@ def heading(text):
     print('####')
     print('')
 
-def pretty_print(data):
-    """Print data in a readable format"""
-    print(yaml.dump(data, allow_unicode=True, default_flow_style=False))
-
 def extract_frontmatter(content):
     """Extract YAML frontmatter from markdown content"""
     frontmatter = {}
@@ -69,13 +69,13 @@ def update_frontmatter(content, updates):
         # No frontmatter exists, create it
         new_frontmatter = yaml.dump(updates, allow_unicode=True, default_flow_style=False)
         return f"---\n{new_frontmatter}---\n{content}"
-    else:
-        # Update existing frontmatter
-        existing = match.group(1)
-        try:
-            current = yaml.load(existing[4:-4], Loader=SafeLoader) or {}
-            current.update(updates)
-            new_frontmatter = yaml.dump(current, allow_unicode=True, default_flow_style=False)
-            return content.replace(existing, f"---\n{new_frontmatter}---\n")
-        except yaml.YAMLError:
-            return content
+
+    # Update existing frontmatter
+    existing = match.group(1)
+    try:
+        current = yaml.load(existing[4:-4], Loader=SafeLoader) or {}
+        current.update(updates)
+        new_frontmatter = yaml.dump(current, allow_unicode=True, default_flow_style=False)
+        return content.replace(existing, f"---\n{new_frontmatter}---\n")
+    except yaml.YAMLError:
+        return content

--- a/docker-resources/utilities.py
+++ b/docker-resources/utilities.py
@@ -1,5 +1,8 @@
 """General utilities"""
 
+import re
+import yaml
+from yaml import SafeLoader
 import os
 
 def env(var, default=None):
@@ -30,3 +33,49 @@ def pretty_print(json_obj):
             separators=(',', ': '),
         ),
     )
+
+def heading(text):
+    """Print a heading"""
+    print('')
+    print('####')
+    print('# ' + text)
+    print('####')
+    print('')
+
+def pretty_print(data):
+    """Print data in a readable format"""
+    print(yaml.dump(data, allow_unicode=True, default_flow_style=False))
+
+def extract_frontmatter(content):
+    """Extract YAML frontmatter from markdown content"""
+    frontmatter = {}
+    pattern = r'^---\n(.*?)\n---\n'
+    match = re.search(pattern, content, re.DOTALL)
+
+    if match:
+        frontmatter_str = match.group(1)
+        try:
+            frontmatter = yaml.load(frontmatter_str, Loader=SafeLoader) or {}
+        except yaml.YAMLError:
+            pass
+    return frontmatter
+
+def update_frontmatter(content, updates):
+    """Update frontmatter with new key-value pairs"""
+    pattern = r'^(---\n.*?\n---\n)'
+    match = re.search(pattern, content, re.DOTALL)
+
+    if not match:
+        # No frontmatter exists, create it
+        new_frontmatter = yaml.dump(updates, allow_unicode=True, default_flow_style=False)
+        return f"---\n{new_frontmatter}---\n{content}"
+    else:
+        # Update existing frontmatter
+        existing = match.group(1)
+        try:
+            current = yaml.load(existing[4:-4], Loader=SafeLoader) or {}
+            current.update(updates)
+            new_frontmatter = yaml.dump(current, allow_unicode=True, default_flow_style=False)
+            return content.replace(existing, f"---\n{new_frontmatter}---\n")
+        except yaml.YAMLError:
+            return content

--- a/docker-resources/utilities.py
+++ b/docker-resources/utilities.py
@@ -67,7 +67,7 @@ def update_frontmatter(content, updates):
 
     if not match:
         # No frontmatter exists, create it
-        new_frontmatter = yaml.dump(updates, allow_unicode=True, default_flow_style=False)
+        new_frontmatter = yaml.dump(updates, allow_unicode=True, default_flow_style=False, sort_keys=False)
         return f"---\n{new_frontmatter}---\n{content}"
 
     # Update existing frontmatter
@@ -75,7 +75,29 @@ def update_frontmatter(content, updates):
     try:
         current = yaml.load(existing[4:-4], Loader=SafeLoader) or {}
         current.update(updates)
-        new_frontmatter = yaml.dump(current, allow_unicode=True, default_flow_style=False)
+        new_frontmatter = yaml.dump(current, allow_unicode=True, default_flow_style=False, sort_keys=False)
         return content.replace(existing, f"---\n{new_frontmatter}---\n")
     except yaml.YAMLError:
         return content
+
+def append_updates_to_frontmatter(content, updates):
+    # Separate frontmatter from the rest of the content
+    if content.startswith('---'):
+        parts = content.split('---\n', 1)
+        # Load YAML part
+        frontmatter = yaml.safe_load(parts[1].split('---')[0].strip())
+        body = parts[1].split('---', 1)[1] if len(parts) > 1 else ''
+    else:
+        frontmatter = {}
+        body = content
+
+    # Append the updates to the frontmatter
+    if 'updates' not in frontmatter:
+        frontmatter['updates'] = updates
+    else:
+        frontmatter['updates'].update(updates)
+
+    # Rebuild the YAML with the new frontmatter
+    new_frontmatter = yaml.dump(frontmatter, default_flow_style=False, sort_keys=False)
+    new_content = f"---\n{new_frontmatter}---\n{body}"
+    return new_content

--- a/example01/test-file.md
+++ b/example01/test-file.md
@@ -1,11 +1,11 @@
 ---
-title: "This should be translated" 
+title: "This should be translated"
 something:
 - whatever: This should be translated
-something_else: "This should be translated" 
+something_else: "This should be translated"
 this_is_the_language_key: en
 ---
 This should be translated
 
     This should not be translated because it is preceded by four spaces and is code
-    // This should be translated because it is a comment
+    // This should be translated because it is a comment d

--- a/example01/test-file.md
+++ b/example01/test-file.md
@@ -1,0 +1,11 @@
+---
+title: "This should be translated" 
+something:
+- whatever: This should be translated
+something_else: "This should be translated" 
+this_is_the_language_key: en
+---
+This should be translated
+
+    This should not be translated because it is preceded by four spaces and is code
+    // This should be translated because it is a comment

--- a/scripts/translate-md.sh
+++ b/scripts/translate-md.sh
@@ -8,7 +8,7 @@ DEST_FOLDER=""
 PROVIDER="microsoft"
 TRANSLATE_KEY="translation"
 TRANSLATE_MESSAGE="Translated by @Provider from @source using @repo on @Date"
-DO_NOT_TRANSLATE_KEYS=()
+DO_NOT_TRANSLATE_KEYS=[]
 REGEX_PROC="False"
 REMOVE_SPAN="False"
 
@@ -25,7 +25,7 @@ usage() {
   echo "  --provider                    Translation provider (default: microsoft)"
   echo "  --translate-key               Frontmatter key for translation info"
   echo "  --translate-message           Translation message template"
-  echo "  --do-not-translate-frontmatter <key>  Key to exclude (can repeat)"
+  echo "  --do-not-translate-frontmatter Keys to exclude"
   echo "  --do-not-translate-regex      Enable regex exclusion"
   echo "  --remove-span-translate-no    Remove <span translate='no'>"
   exit 1
@@ -42,9 +42,7 @@ while [[ $# -gt 0 ]]; do
     --provider) PROVIDER="$2"; shift 2 ;;
     --translate-key) TRANSLATE_KEY="$2"; shift 2 ;;
     --translate-message) TRANSLATE_MESSAGE="$2"; shift 2 ;;
-    --do-not-translate-frontmatter)
-      DO_NOT_TRANSLATE_KEYS+=("$2")
-      shift 2 ;;
+    --do-not-translate-frontmatter) DO_NOT_TRANSLATE_KEYS=("$2"); shift 2 ;;
     --do-not-translate-regex) REGEX_PROC="True"; shift ;;
     --remove-span-translate-no) REMOVE_SPAN="True"; shift ;;
     *) echo "Unknown option: $1"; usage ;;
@@ -93,6 +91,7 @@ docker run \
   --langkey "$LANGKEY" \
   --translate-key "$TRANSLATE_KEY" \
   --translate-message "$TRANSLATE_MESSAGE" \
-  $(for key in "${DO_NOT_TRANSLATE_KEYS[@]}"; do echo "--do-not-translate-frontmatter $key"; done) \
+  --do-not-translate-frontmatter "$DO_NOT_TRANSLATE_KEYS" \
+  $DNT_FRONTMATTER \
   $DO_REGEX_FLAG \
   $REMOVE_SPAN_FLAG

--- a/scripts/translate-md.sh
+++ b/scripts/translate-md.sh
@@ -70,6 +70,9 @@ mkdir -p $(pwd)/do-not-commit
 docker build -t local-translate-api-image .
 
 docker run \
+  -e MS_ENDPOINT="$MS_ENDPOINT" \
+  -e MS_LOC="$MS_LOC" \
+  -e MS_KEY="$MS_KEY" \
   -v $(pwd)/example01:/app/example01 \
   -v $(pwd)/docker-resources:/app \
   -v $(pwd)/do-not-commit:/app/do-not-commit \
@@ -83,4 +86,3 @@ docker run \
   --translate-key "$TRANSLATE_KEY" \
   --translate-message "$TRANSLATE_MESSAGE" \
   $(for key in "${DO_NOT_TRANSLATE_KEYS[@]}"; do echo "--do-not-translate-frontmatter $key"; done)
-

--- a/scripts/translate-md.sh
+++ b/scripts/translate-md.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -e
+
+# Default values
+LANGKEY="lang"
+DEST_FOLDER=""
+PROVIDER="microsoft"
+TRANSLATE_KEY="translation"
+TRANSLATE_MESSAGE="Translated by @Provider from @source using @repo on @Date"
+DO_NOT_TRANSLATE_KEYS=()
+
+# Helper to show usage
+usage() {
+  echo "Usage: $0 --source <file> --source-lang <lang> --dest-lang <lang> [options]"
+  echo
+  echo "Options:"
+  echo "  --source                      Source markdown file (required)"
+  echo "  --langkey                    Frontmatter language key (default: lang)"
+  echo "  --source-lang                Source language (required)"
+  echo "  --dest-lang                  Destination language (required)"
+  echo "  --destination-folder         Output folder (default: same as source)"
+  echo "  --provider                   Translation provider (default: microsoft)"
+  echo "  --translate-key              Frontmatter key for translation info (default: translation)"
+  echo "  --translate-message          Message template (default: 'Translated by @Provider from @source using @repo on @Date')"
+  echo "  --do-not-translate-frontmatter <key>  Frontmatter key to exclude from translation (can be repeated)"
+  exit 1
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source) SOURCE="$2"; shift 2 ;;
+    --langkey) LANGKEY="$2"; shift 2 ;;
+    --source-lang) SOURCE_LANG="$2"; shift 2 ;;
+    --dest-lang) DEST_LANG="$2"; shift 2 ;;
+    --destination-folder) DEST_FOLDER="$2"; shift 2 ;;
+    --provider) PROVIDER="$2"; shift 2 ;;
+    --translate-key) TRANSLATE_KEY="$2"; shift 2 ;;
+    --translate-message) TRANSLATE_MESSAGE="$2"; shift 2 ;;
+    --do-not-translate-frontmatter)
+      DO_NOT_TRANSLATE_KEYS+=("$2")
+      shift 2 ;;
+    *)
+      echo "Unknown option: $1"
+      usage ;;
+  esac
+done
+
+# Check required arguments
+[[ -z "$SOURCE" || -z "$SOURCE_LANG" || -z "$DEST_LANG" ]] && usage
+
+# Determine destination folder
+if [[ -z "$DEST_FOLDER" ]]; then
+  DEST_FOLDER=$(dirname "$SOURCE")
+fi
+
+# Create destination folder if it doesn't exist
+mkdir -p "$DEST_FOLDER"
+
+# Destination file
+BASENAME=$(basename "$SOURCE" .md)
+DEST_FILE="$DEST_FOLDER/${BASENAME}.${DEST_LANG}.md"
+
+docker pull python:alpine
+# docker build -t local-translate-api-image .
+
+mkdir -p $(pwd)/do-not-commit
+
+docker build -t local-translate-api-image .
+
+docker run \
+  -v $(pwd)/example01:/app/example01 \
+  -v $(pwd)/docker-resources:/app \
+  -v $(pwd)/do-not-commit:/app/do-not-commit \
+  local-translate-api-image \
+  /app/translate_markdown.py \
+  --source "/app/$SOURCE" \
+  --source-lang "$SOURCE_LANG" \
+  --dest-lang "$DEST_LANG" \
+  --provider "$PROVIDER" \
+  --langkey "$LANGKEY" \
+  --translate-key "$TRANSLATE_KEY" \
+  --translate-message "$TRANSLATE_MESSAGE" \
+  $(for key in "${DO_NOT_TRANSLATE_KEYS[@]}"; do echo "--do-not-translate-frontmatter $key"; done)
+

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,8 @@
 # Tests
 set -e
 
+mkdir -p ./do-not-commit
+
 # See https://github.com/dcycle/docker-python-lint
 echo ""
 echo "To ignore a line, you can add this before the line"
@@ -21,3 +23,19 @@ docker run --rm \
   -e MS_SIMULATE="true" \
   local-translate-api-image preflight.py
 echo "[ok] preflight.py passes if environment vars are set"
+
+./scripts/translate-md.sh --source example01/test-file.md \
+  --langkey this_is_the_language_key \
+  --source-lang en \
+  --dest-lang fr \
+  --destination-folder do-not-commit \
+  --provider simulate \
+  --translate-key translation_info_key \
+  --translate-message "Translated by @provider from @source using @repo on @date" \
+  --do-not-translate-frontmatter '["title", "something", "whatever"]' \
+  --do-not-translate-regex \
+  --remove-span-translate-no
+
+echo "[ok] translate-md.sh works with simulator"
+
+rm -rf ./do-not-commit


### PR DESCRIPTION
1.  verify translation of markdown file.

Add a file in ./example01 which has the title "test-file.md" and the following contents:

```
---
title: "This should be translated" 
something:
- whatever: This should be translated
something_else: "This should be translated" 
this_is_the_language_key: en
---
This should be translated

    This should not be translated because it is preceded by four spaces and is code
    // This should be translated because it is a comment

```


Run 

```
./scripts/translate-md.sh \                                                                                                   
  --source example01/test-file.md \
  --langkey this_is_the_language_key \
  --source-lang en \
  --dest-lang fr \
  --destination-folder do-not-commit \
  --provider simulate \
  --translate-key translation_info_key \
  --translate-message "Translated by @provider from @source using @repo on @date" \
  --do-not-translate-frontmatter '["title", "something", "whatever"]' \
  --do-not-translate-regex \
  --remove-span-translate-no

```

you can find output at ./do-not-commit/test-file.fr.md    


again if you run 

2.  ==> the microsoft translation system will replace "this is a text" with « ceci est un texte », which is fine in the body of the text, but not the frontmatter. I tweaked the simulator so that it replaces all instances of " with ». *Your code should not replace " with » in the frontmatter. So, in the frontmatter, you might want to create a processors which wraps instances of " with START_NO_TRANSLATE"END_NO_TRANSLATE, so that we do not translate it.

Run ./test.sh and verify the output.

