### PR TITLE
CHANGE 3: add the --force-if-same-hash parameter #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,27 @@ example:-
       --do-not-translate-regex \
       --remove-span-translate-no
 
+Force if same hash parameter
+-----
+    During development if you would like to be able to overwrite the translated file if necessary then
+    use --force-if-same-hash parameter in command.
+
+    ```
+    ./scripts/translate-md.sh --source example01/test-file.md \
+        --langkey this_is_the_language_key \
+        --source-lang en \
+        --dest-lang fr \
+        --destination-folder do-not-commit \
+        --provider simulate \
+        --translate-key translation_info_key \
+        --translate-message "Translated by @provider from @source using @repo on @date" \
+        --do-not-translate-frontmatter '["title", "something", "whatever"]' \
+        --do-not-translate-regex \
+        --remove-span-translate-no \
+        --force-if-same-hash
+    ```
+
+
 More resources
 -----
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ example:-
 Force if same hash parameter
 -----
     During development if you would like to be able to overwrite the translated file if necessary then
-    use --force-if-same-hash parameter in command.
+    use --force-if-same-hash parameter in the command.
 
     ```
     ./scripts/translate-md.sh --source example01/test-file.md \

--- a/docker-resources/translate_markdown.py
+++ b/docker-resources/translate_markdown.py
@@ -15,6 +15,7 @@ import my_translate
 # pylint: disable=E0401
 import utilities
 
+
 def generate_hash(content):
     """
     Generate an MD5 hash from a given string.
@@ -158,6 +159,7 @@ def main():
     parser.add_argument('--do-not-translate-frontmatter', type=json.loads, default=[])
     parser.add_argument('--do-not-translate-regex', action='store_true', default=False)
     parser.add_argument('--remove-span-translate-no', action='store_true', default=False)
+    parser.add_argument('--force-if-same-hash', action='store_true', default=False)
 
     args = parser.parse_args()
 
@@ -212,10 +214,14 @@ def main():
 
     source_hash = generate_hash(markdown_content)
 
-    # Check existing translation
     dest_file = args.destination
-    if check_existing_translation(dest_file, source_hash, args):
-        return
+    # If args.force_if_same_hash: This checks if the flag is not false or else
+    # env is not dev the only check hash is generated already.
+
+    if not args.force_if_same_hash :
+        # Check existing translation
+        if check_existing_translation(dest_file, source_hash, args):
+            return
 
     preprocessors.append({
         'name': 'escape-double-slash',

--- a/scripts/translate-md.sh
+++ b/scripts/translate-md.sh
@@ -11,6 +11,7 @@ TRANSLATE_MESSAGE="Translated by @Provider from @source using @repo on @Date"
 DO_NOT_TRANSLATE_KEYS=[]
 REGEX_PROC="False"
 REMOVE_SPAN="False"
+FORCE_IF_SAME_HASH="False"
 
 # Usage function
 usage() {
@@ -28,6 +29,7 @@ usage() {
   echo "  --do-not-translate-frontmatter Keys to exclude"
   echo "  --do-not-translate-regex      Enable regex exclusion"
   echo "  --remove-span-translate-no    Remove <span translate='no'>"
+  echo "  --force-if-same-hash          The translation should take place even if the hash is the same."
   exit 1
 }
 
@@ -45,6 +47,7 @@ while [[ $# -gt 0 ]]; do
     --do-not-translate-frontmatter) DO_NOT_TRANSLATE_KEYS=("$2"); shift 2 ;;
     --do-not-translate-regex) REGEX_PROC="True"; shift ;;
     --remove-span-translate-no) REMOVE_SPAN="True"; shift ;;
+    --force-if-same-hash) FORCE_IF_SAME_HASH="True"; shift ;;
     *) echo "Unknown option: $1"; usage ;;
   esac
 done
@@ -72,6 +75,7 @@ mkdir -p $(pwd)/do-not-commit
 # Prepare optional flags
 [[ "$REGEX_PROC" == "True" ]] && DO_REGEX_FLAG="--do-not-translate-regex"
 [[ "$REMOVE_SPAN" == "True" ]] && REMOVE_SPAN_FLAG="--remove-span-translate-no"
+[[ "$FORCE_IF_SAME_HASH" == "True" ]] && FORCE_IF_SAME_HASH_FLAG="--force-if-same-hash"
 
 # Run Docker translation
 docker run \
@@ -94,4 +98,5 @@ docker run \
   --do-not-translate-frontmatter "$DO_NOT_TRANSLATE_KEYS" \
   $DNT_FRONTMATTER \
   $DO_REGEX_FLAG \
-  $REMOVE_SPAN_FLAG
+  $REMOVE_SPAN_FLAG \
+  $FORCE_IF_SAME_HASH_FLAG

--- a/test.sh
+++ b/test.sh
@@ -36,6 +36,32 @@ echo "[ok] preflight.py passes if environment vars are set"
   --do-not-translate-regex \
   --remove-span-translate-no
 
+./scripts/translate-md.sh --source example01/test-file.md \
+  --langkey this_is_the_language_key \
+  --source-lang en \
+  --dest-lang fr \
+  --destination-folder do-not-commit \
+  --provider simulate \
+  --translate-key translation_info_key \
+  --translate-message "Translated by @provider from @source using @repo on @date" \
+  --do-not-translate-frontmatter '["title", "something", "whatever"]' \
+  --do-not-translate-regex \
+  --remove-span-translate-no \
+  --force-if-same-hash
+
+
+./scripts/translate-md.sh --source example01/test-file.md \
+  --langkey this_is_the_language_key \
+  --source-lang en \
+  --dest-lang fr \
+  --destination-folder do-not-commit \
+  --provider simulate \
+  --translate-key translation_info_key \
+  --translate-message "Translated by @provider from @source using @repo on @date" \
+  --do-not-translate-frontmatter '["title", "something", "whatever"]' \
+  --do-not-translate-regex \
+  --remove-span-translate-no
+
 echo "[ok] translate-md.sh works with simulator"
 
 rm -rf ./do-not-commit


### PR DESCRIPTION
Force if same hash parameter
-----

    During development if you would like to overwrite the translated file if necessary then
    use --force-if-same-hash parameter in the command.


```
            ./scripts/translate-md.sh --source example01/test-file.md \
                --langkey this_is_the_language_key \
                --source-lang en \
                --dest-lang fr \
                --destination-folder do-not-commit \
                --provider simulate \
                --translate-key translation_info_key \
                --translate-message "Translated by @provider from @source using @repo on @date" \
                --do-not-translate-frontmatter '["title", "something", "whatever"]' \
                --do-not-translate-regex \
                --remove-span-translate-no \
                --force-if-same-hash

```
