### PR TITLE
Improvements to the translate markdown script #8

### DIFF
--- a/docker-resources/my_simulated.py
+++ b/docker-resources/my_simulated.py
@@ -1,12 +1,13 @@
 """Simulation of a translation; does nothing"""
 
-def replace(text, translate_me = True):
-    """Replace all e's with o's"""
+def replace(text, translate_me=True):
+    """Replace all e's, i's, o's, and u's with 'a's, unless inside a no-translate span"""
     if not text:
         return ''
+
     if translate_me:
         if text.startswith('<span translate="no">'):
-            return replace(text, False)
+            return '<span translate="no">' + replace(text[len('<span translate="no">'):], False)
         first = text[0]
         first = first.replace('e', 'a')
         first = first.replace('i', 'a')
@@ -15,8 +16,9 @@ def replace(text, translate_me = True):
         first = first.replace('"', '»')
     else:
         if text.startswith('</span>'):
-            return replace(text, True)
+            return '</span>' + replace(text[len('</span>'):], True)
         first = text[0]
+
     return first + replace(text[1:], translate_me)
 
 # pylint: disable=W0613

--- a/docker-resources/my_translate.py
+++ b/docker-resources/my_translate.py
@@ -40,8 +40,6 @@ def translate(data):
         case _:
             raise EnvironmentError('provider must be set in my_transate.translate()')
 
-    print('ret', ret)
-
     for languages in ret[0]['translations']:
         languages['text'] = process(languages['text'], postprocessors)
 

--- a/docker-resources/preflight.py
+++ b/docker-resources/preflight.py
@@ -298,8 +298,7 @@ utilities.pretty_print(my_translate.translate({
   }
 ))
 
-# title, description and regex matched text shouldn't be translated.
-# Ensure regex matches your text other wise we will end up in a error
+# Preserve double quotes of frontmatter value
 utilities.pretty_print(my_translate.translate({
     'provider': PROVIDER,
     'text': """

--- a/docker-resources/processor_do_not_translate_frontmatter_doublequote.py
+++ b/docker-resources/processor_do_not_translate_frontmatter_doublequote.py
@@ -139,31 +139,26 @@ def wrap_key_in_no_translate_span(line):
 
 def wrap_quoted_values(line):
     """
-    Wraps the quoted values in a line (after the colon) in a 'no-translate' span.
-
-    Args:
-    - line (str): The line to wrap.
-
-    Returns:
-    - str: The line with quoted values wrapped in a 'no-translate' span.
+    Wraps quoted values in a 'no-translate' span, but skips wrapping
+    if the value part is already entirely a <span translate="no">__START_NO_TRANSLATE__...__END_NO_TRANSLATE__</span>.
     """
+
     key_part, value_part = line.split(':', 1)
+    value_part = value_part.strip()
 
-    # Define the pattern for matching quoted values
-    pattern = r'("[^"]*")'
+    # Skip processing if already a wrapped no-translate span
+    already_wrapped_pattern = r'^<span translate="no">__START_NO_TRANSLATE__.*?__END_NO_TRANSLATE__</span>$'
+    if re.fullmatch(already_wrapped_pattern, value_part):
+        return f'{key_part}: {value_part}'
 
-    # Define the replacement function for quoted values
+    # Pattern to find quoted values
+    pattern = r'"([^"]*?)"'
+
     def wrap_quoted_value(match):
-        # Get the matched quoted string (without the surrounding quotes)
-        quoted_value = match.group(1)[1:-1]
-        # Wrap the quotes and the quoted value in no-translate spans
-        return (
-            '<span translate="no">__START_NO_TRANSLATE__"__END_NO_TRANSLATE__</span>'
-            + quoted_value +
-            '<span translate="no">__START_NO_TRANSLATE__"__END_NO_TRANSLATE__</span>'
-        )
+        quoted_value = match.group(1)
+        return f'<span translate="no">__START_NO_TRANSLATE__{quoted_value}__END_NO_TRANSLATE__</span>'
 
-    # Apply the regex substitution using the pattern and replacement function
+    # Apply substitution
     value_part = re.sub(pattern, wrap_quoted_value, value_part)
 
-    return f'{key_part}:{value_part}'
+    return f'{key_part}: {value_part}'

--- a/docker-resources/translate_markdown.py
+++ b/docker-resources/translate_markdown.py
@@ -83,7 +83,6 @@ def check_existing_translation(dest_file, source_hash, args):
     with open(dest_file, 'r', encoding='utf-8') as f:
         content = f.read()
         frontmatter = utilities.extract_frontmatter(content)
-
         if frontmatter.get(args.translate_key, {}).get('hash') == source_hash:
             print(f"Did not translate because source hash of {args.source}, {source_hash}, "
                   f"is the same as the source hash key in the existing destination file")
@@ -155,7 +154,10 @@ def main():
       '--translate-message',
       default='Translated by @Provider from @source using @repo on @Date'
     )
-    parser.add_argument('--do-not-translate-frontmatter-double-quote', action='store_true', default=False)
+    parser.add_argument('--do-not-translate-frontmatter-double-quote',
+      action='store_true',
+      default=False
+    )
     parser.add_argument('--do-not-translate-frontmatter', type=json.loads, default=[])
     parser.add_argument('--do-not-translate-regex', action='store_true', default=False)
     parser.add_argument('--remove-span-translate-no', action='store_true', default=False)
@@ -184,12 +186,6 @@ def main():
     preprocessors = []
     postprocessors = []
 
-    if args.do_not_translate_frontmatter_double_quote:
-        preprocessors.append({
-            'name': 'do-not-translate-frontmatter-double-quote',
-            'args': {}
-        })
-
     # Add 'do-not-translate-frontmatter' if the argument is set
     if args.do_not_translate_frontmatter:
         frontmatter_keys = args.do_not_translate_frontmatter
@@ -198,6 +194,12 @@ def main():
             'args': {
                 'frontmatter': frontmatter_keys
             }
+        })
+
+    if args.do_not_translate_frontmatter_double_quote:
+        preprocessors.append({
+            'name': 'do-not-translate-frontmatter-double-quote',
+            'args': {}
         })
 
     # Add 'do-not-translate-regex' if the argument is set

--- a/docker-resources/translate_markdown.py
+++ b/docker-resources/translate_markdown.py
@@ -84,7 +84,9 @@ def check_existing_translation(dest_file, source_hash, args):
     with open(dest_file, 'r', encoding='utf-8') as f:
         content = f.read()
         frontmatter = utilities.extract_frontmatter(content)
-        if frontmatter.get(args.translate_key, {}).get('hash') == source_hash:
+        # First, check if the value under translate_key is a dictionary containing a hash
+        value = frontmatter.get(args.translate_key)
+        if isinstance(value, dict) and value.get('hash') == source_hash:
             print(f"Did not translate because source hash of {args.source}, {source_hash}, "
                   f"is the same as the source hash key in the existing destination file")
             return True

--- a/docker-resources/translate_markdown.py
+++ b/docker-resources/translate_markdown.py
@@ -57,7 +57,7 @@ def replace_message_placeholders(message, args):
     }
     for placeholder, value in replacements.items():
         message = message.replace(placeholder, value)
-    return message
+    return f'"{message}"'
 
 def check_existing_translation(dest_file, source_hash, args):
     """
@@ -248,8 +248,6 @@ def main():
       'preprocessors': preprocessors,
       'postprocessors': postprocessors
     })
-
-    utilities.pretty_print(result)
 
     # Extract and write the translated content to the file
     extract_and_write_translation(result, dest_file, args, source_hash)

--- a/docker-resources/translate_markdown.py
+++ b/docker-resources/translate_markdown.py
@@ -155,6 +155,7 @@ def main():
       '--translate-message',
       default='Translated by @Provider from @source using @repo on @Date'
     )
+    parser.add_argument('--do-not-translate-frontmatter-double-quote', action='store_true', default=False)
     parser.add_argument('--do-not-translate-frontmatter', type=json.loads, default=[])
     parser.add_argument('--do-not-translate-regex', action='store_true', default=False)
     parser.add_argument('--remove-span-translate-no', action='store_true', default=False)
@@ -182,6 +183,12 @@ def main():
 
     preprocessors = []
     postprocessors = []
+
+    if args.do_not_translate_frontmatter_double_quote:
+        preprocessors.append({
+            'name': 'do-not-translate-frontmatter-double-quote',
+            'args': {}
+        })
 
     # Add 'do-not-translate-frontmatter' if the argument is set
     if args.do_not_translate_frontmatter:

--- a/example01/test-file.md
+++ b/example01/test-file.md
@@ -1,5 +1,5 @@
 ---
-title: "This should be translated"
+title: "This should be 'test' translated"
 something:
 - whatever: This should be translated
 something_else: "This should be translated"

--- a/example01/test-file.md
+++ b/example01/test-file.md
@@ -1,5 +1,5 @@
 ---
-title: "This should be 'test' translated"
+title: "This: should be 'test' translated"
 something:
 - whatever: This should be translated
 something_else: "This should be translated"

--- a/scripts/translate-md.sh
+++ b/scripts/translate-md.sh
@@ -11,6 +11,7 @@ TRANSLATE_MESSAGE="Translated by @Provider from @source using @repo on @Date"
 DO_NOT_TRANSLATE_KEYS=[]
 REGEX_PROC="False"
 REMOVE_SPAN="False"
+DNT_FRONTMATTER_DOUBLE_QUOTE="False"
 
 # Usage function
 usage() {
@@ -26,6 +27,7 @@ usage() {
   echo "  --translate-key               Frontmatter key for translation info"
   echo "  --translate-message           Translation message template"
   echo "  --do-not-translate-frontmatter Keys to exclude"
+  echo "  --do-not-translate-frontmatter-double-quote dont translate double quotes in frontmatter"
   echo "  --do-not-translate-regex      Enable regex exclusion"
   echo "  --remove-span-translate-no    Remove <span translate='no'>"
   exit 1
@@ -43,6 +45,7 @@ while [[ $# -gt 0 ]]; do
     --translate-key) TRANSLATE_KEY="$2"; shift 2 ;;
     --translate-message) TRANSLATE_MESSAGE="$2"; shift 2 ;;
     --do-not-translate-frontmatter) DO_NOT_TRANSLATE_KEYS=("$2"); shift 2 ;;
+    --do-not-translate-frontmatter-double-quote) DNT_FRONTMATTER_DOUBLE_QUOTE="True"; shift ;;
     --do-not-translate-regex) REGEX_PROC="True"; shift ;;
     --remove-span-translate-no) REMOVE_SPAN="True"; shift ;;
     *) echo "Unknown option: $1"; usage ;;
@@ -72,6 +75,7 @@ mkdir -p $(pwd)/do-not-commit
 # Prepare optional flags
 [[ "$REGEX_PROC" == "True" ]] && DO_REGEX_FLAG="--do-not-translate-regex"
 [[ "$REMOVE_SPAN" == "True" ]] && REMOVE_SPAN_FLAG="--remove-span-translate-no"
+[[ "$DNT_FRONTMATTER_DOUBLE_QUOTE" == "True" ]] && DNT_FRONTMATTER_DOUBLE_QUOTE_FLAG="--do-not-translate-frontmatter-double-quote"
 
 # Run Docker translation
 docker run \
@@ -94,4 +98,5 @@ docker run \
   --do-not-translate-frontmatter "$DO_NOT_TRANSLATE_KEYS" \
   $DNT_FRONTMATTER \
   $DO_REGEX_FLAG \
-  $REMOVE_SPAN_FLAG
+  $REMOVE_SPAN_FLAG \
+  $DNT_FRONTMATTER_DOUBLE_QUOTE_FLAG

--- a/test.sh
+++ b/test.sh
@@ -64,10 +64,40 @@ echo "[ok] preflight.py passes if environment vars are set"
   --provider simulate \
   --translate-key translation_info_key \
   --translate-message "Translated by @provider from @source using @repo on @date" \
+  --do-not-translate-frontmatter-double-quote \
   --do-not-translate-frontmatter '["title", "something", "whatever"]' \
   --do-not-translate-regex \
   --remove-span-translate-no
 
+# create translation again using --force-if-same-hash
+./scripts/translate-md.sh --source example01/test-file.md \
+  --langkey this_is_the_language_key \
+  --source-lang en \
+  --dest-lang fr \
+  --destination-folder do-not-commit \
+  --provider simulate \
+  --translate-key translation_info_key \
+  --translate-message "Translated by @provider from @source using @repo on @date" \
+  --do-not-translate-frontmatter '["title", "something", "whatever"]' \
+  --do-not-translate-regex \
+  --remove-span-translate-no \
+  --force-if-same-hash
+
+./scripts/translate-md.sh --source example01/test-file.md \
+  --langkey this_is_the_language_key \
+  --source-lang en \
+  --dest-lang fr \
+  --destination-folder do-not-commit \
+  --provider simulate \
+  --translate-key translation_info_key \
+  --translate-message "Translated by @provider from @source using @repo on @date" \
+  --do-not-translate-frontmatter '["title", "something", "whatever"]' \
+  --do-not-translate-regex \
+  --remove-span-translate-no \
+  --force-if-same-hash
+
 echo "[ok] translate-md.sh works with simulator"
+
+cat ./do-not-commit/test-file.fr.md
 
 rm -rf ./do-not-commit

--- a/test.sh
+++ b/test.sh
@@ -24,17 +24,21 @@ docker run --rm \
   local-translator-api-image preflight.py
 echo "[ok] preflight.py passes if environment vars are set"
 
-./scripts/translate-md.sh --source example01/test-file.md \
-  --langkey this_is_the_language_key \
-  --source-lang en \
-  --dest-lang fr \
-  --destination-folder do-not-commit \
-  --provider simulate \
-  --translate-key translation_info_key \
-  --translate-message "Translated by @provider from @source using @repo on @date" \
-  --do-not-translate-frontmatter '["title", "something", "whatever"]' \
-  --do-not-translate-regex \
-  --remove-span-translate-no
+# verify double quotes wrapping in frontformatter
+ rm -rf do-not-commit
+    ./scripts/translate-md.sh \
+      --source example01/test-file.md \
+      --langkey this_is_the_language_key \
+      --source-lang en \
+      --dest-lang fr \
+      --destination-folder do-not-commit \
+      --provider simulate \
+      --translate-key translation_info_key \
+      --translate-message "Translated by @provider from @source using @repo on @date" \
+      --do-not-translate-frontmatter-double-quote \
+      --do-not-translate-frontmatter '["title", "something", "whatever"]' \
+      --do-not-translate-regex \
+      --remove-span-translate-no
 
 echo "[ok] translate-md.sh works with simulator"
 

--- a/test.sh
+++ b/test.sh
@@ -40,6 +40,7 @@ echo "[ok] preflight.py passes if environment vars are set"
       --do-not-translate-regex \
       --remove-span-translate-no
 
+# create translation again using --force-if-same-hash
 ./scripts/translate-md.sh --source example01/test-file.md \
   --langkey this_is_the_language_key \
   --source-lang en \
@@ -48,12 +49,13 @@ echo "[ok] preflight.py passes if environment vars are set"
   --provider simulate \
   --translate-key translation_info_key \
   --translate-message "Translated by @provider from @source using @repo on @date" \
+  --do-not-translate-frontmatter-double-quote \
   --do-not-translate-frontmatter '["title", "something", "whatever"]' \
   --do-not-translate-regex \
   --remove-span-translate-no \
   --force-if-same-hash
 
-
+# throw error hash if same hash present
 ./scripts/translate-md.sh --source example01/test-file.md \
   --langkey this_is_the_language_key \
   --source-lang en \

--- a/test.sh
+++ b/test.sh
@@ -92,6 +92,7 @@ echo "[ok] preflight.py passes if environment vars are set"
   --translate-key translation_info_key \
   --translate-message "Translated by @provider from @source using @repo on @date" \
   --do-not-translate-frontmatter '["title", "something", "whatever"]' \
+  --do-not-translate-frontmatter-double-quote \
   --do-not-translate-regex \
   --remove-span-translate-no \
   --force-if-same-hash


### PR DESCRIPTION
I have remove pyaml package related functions for accessing frontformatter and updating frontformatter in yaml. Because default behavior of pyaml unquoting the " and ' wrapper in frontformatter.   Now I have added custom codes to accessing frontformatter and updating frontformatter.

1. quotes in frontmatter preserved now.
2. translation message are rendering in single line.


kindly run below command to verify . 
```
   rm -rf do-not-commit
    ./scripts/translate-md.sh \
      --source example01/test-file.md \
      --langkey this_is_the_language_key \
      --source-lang en \
      --dest-lang fr \
      --destination-folder do-not-commit \
      --provider simulate \
      --translate-key translation_info_key \
      --translate-message "Translated by @provider from @source using @repo on @date" \
      --do-not-translate-frontmatter-double-quote \
      --do-not-translate-frontmatter '["title", "something", "whatever"]' \
      --do-not-translate-regex \
      --remove-span-translate-no

```